### PR TITLE
Update copyright year

### DIFF
--- a/docs.vmst.io/config.yml
+++ b/docs.vmst.io/config.yml
@@ -3,7 +3,7 @@ relativeURLs: true
 baseURL: ''
 title: docs·vmst·io
 author: vmst·io
-copyright: Copyright © 2022 vmst·io Team
+copyright: Copyright © 2022-2023 vmst·io Team
 languageCode: en
 paginate: 5
 enableInlineShortcodes: true


### PR DESCRIPTION
Going with `2022-2023`, but we could also consider `2022-Present`.